### PR TITLE
Identicon hashes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ serde_yaml = "0.7"
 chrono = "0.4"
 reqwest = "0.7"
 argon2rs = { version = "0.2", features = ["simd"] }
+rust-crypto = "^0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ chrono = "0.4"
 reqwest = "0.7"
 argon2rs = { version = "0.2", features = ["simd"] }
 rust-crypto = "^0.2"
+itertools = "0.6"

--- a/app/elm/Data/User.elm
+++ b/app/elm/Data/User.elm
@@ -11,7 +11,7 @@ type alias User =
     { name : Maybe String
     , email : Maybe String
     , url : Maybe String
-    , hash : Maybe String
+    , iphash : Maybe String
     , preview : Bool
     }
 
@@ -26,7 +26,7 @@ decoder =
         |> required "name" (Decode.nullable Decode.string)
         |> required "email" (Decode.nullable Decode.string)
         |> required "url" (Decode.nullable Decode.string)
-        |> required "hash" (Decode.nullable Decode.string)
+        |> required "iphash" (Decode.nullable Decode.string)
         |> required "preview" Decode.bool
 
 
@@ -36,6 +36,6 @@ encode user =
         [ "name" => EncodeExtra.maybe Encode.string user.name
         , "email" => EncodeExtra.maybe Encode.string user.email
         , "url" => EncodeExtra.maybe Encode.string user.url
-        , "hash" => EncodeExtra.maybe Encode.string user.hash
+        , "iphash" => EncodeExtra.maybe Encode.string user.iphash
         , "preview" => Encode.bool user.preview
         ]

--- a/app/elm/Main.elm
+++ b/app/elm/Main.elm
@@ -25,7 +25,7 @@ init location =
             , email = Nothing
             , url = Nothing
             , preview = False
-            , hash = Nothing
+            , iphash = Nothing
             }
       , count = 0
       , post = location

--- a/app/elm/Request/User.elm
+++ b/app/elm/Request/User.elm
@@ -8,7 +8,7 @@ import HttpBuilder exposing (RequestBuilder, withQueryParams)
 -}
 hash : Http.Request String
 hash =
-    "/hash"
+    "/iphash"
         |> HttpBuilder.get
         |> HttpBuilder.withExpect Http.expectString
         |> HttpBuilder.toRequest

--- a/app/elm/Update.elm
+++ b/app/elm/Update.elm
@@ -184,14 +184,8 @@ update msg model =
             let
                 user =
                     model.user
-
-                store =
-                    if List.all isNothing [ user.name, user.email, user.url ] then
-                        Just result
-                    else
-                        Nothing
             in
-            { model | user = { user | hash = store } } ! []
+            { model | user = { user | iphash = Just result } } ! []
 
         Hash (Err _) ->
             model ! []

--- a/app/elm/View.elm
+++ b/app/elm/View.elm
@@ -1,5 +1,6 @@
 module View exposing (view)
 
+import Crypto.Hash
 import Data.User as User exposing (User)
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -80,6 +81,10 @@ getIdentity user =
             [ user.name ? "", user.email ? "", user.url ? "" ]
     in
     if List.all String.isEmpty data then
-        user.hash ? ""
+        user.iphash ? ""
     else
-        String.join ", " data
+        Crypto.Hash.sha224 (String.join "b" data)
+
+
+
+--Join with b since it gives the authors' credentials a cool identicon

--- a/app/elm/elm-package.json
+++ b/app/elm/elm-package.json
@@ -17,6 +17,7 @@
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",
         "elm-lang/navigation": "2.1.0 <= v < 3.0.0",
+        "ktonon/elm-crypto": "1.1.0 <= v < 2.0.0",
         "lukewestby/elm-http-builder": "5.1.0 <= v < 6.0.0",
         "pablohirafuji/elm-markdown": "2.0.4 <= v < 3.0.0",
         "pukkamustard/elm-identicon": "3.0.0 <= v < 4.0.0"

--- a/migrations/20170719094701_create_oration/up.sql
+++ b/migrations/20170719094701_create_oration/up.sql
@@ -21,6 +21,7 @@ CREATE TABLE comments (
     author VARCHAR,
     email VARCHAR,
     website VARCHAR,
+    hash VARCHAR NOT NULL,
     likes INTEGER DEFAULT 0,
     dislikes INTEGER DEFAULT 0,
     voters VARCHAR NOT NULL

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ extern crate yansi;
 extern crate crypto;
 extern crate reqwest;
 extern crate serde_yaml;
+extern crate itertools;
 #[macro_use(log)]
 extern crate log;
 
@@ -72,8 +73,6 @@ use yansi::Paint;
 use config::Config;
 use crypto::digest::Digest;
 use crypto::sha2::Sha224;
-
-pub const LENGTH: usize = 16;
 
 /// Serve up the index file, which ultimately launches the Elm app.
 #[get("/")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,8 @@ extern crate diesel_codegen;
 extern crate r2d2_diesel;
 extern crate r2d2;
 extern crate yansi;
-extern crate argon2rs;
+//extern crate argon2rs;
+extern crate crypto;
 extern crate reqwest;
 extern crate serde_yaml;
 #[macro_use(log)]
@@ -69,6 +70,8 @@ use models::threads;
 use std::process;
 use yansi::Paint;
 use config::Config;
+use crypto::digest::Digest;
+use crypto::sha2::Sha224;
 
 pub const LENGTH: usize = 16;
 
@@ -161,24 +164,16 @@ fn new_comment<'a>(
     response
 }
 
-/// Gets a hash from a clients IP.
-#[get("/hash")]
-fn get_hash(config: State<Config>, remote_addr: SocketAddr) -> String {
+/// Gets a Sha224 hash from a clients IP.
+#[get("/iphash")]
+fn get_iphash(remote_addr: SocketAddr) -> String {
     let ip_addr = remote_addr.ip().to_string();
-
-    // We don't need this to be long and the process is not crazy fast, so let's drop the length.
-    let mut hash = [0; LENGTH];
-    //This is not a password, so use the faster 2d variant
-    let a2 = argon2rs::Argon2::default(argon2rs::Variant::Argon2d);
-    a2.hash(
-        &mut hash,
-        ip_addr.as_bytes(),
-        config.salt.as_bytes(),
-        &[],
-        &[],
-    );
-
-    hash.iter().map(|b| format!("{:02x}", b)).collect()
+    // create a Sha224 object
+    let mut hasher = Sha224::new();
+    // write input message
+    hasher.input_str(&ip_addr);
+    // read hash digest
+    hasher.result_str()
 }
 
 /// Test function that returns the session hash from the database.
@@ -268,7 +263,7 @@ fn rocket() -> (rocket::Rocket, db::Conn, String) {
             index,
             static_files::files,
             new_comment,
-            get_hash,
+            get_iphash,
             get_session,
             get_comment_count,
             get_comments,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -11,6 +11,7 @@ table! {
         author -> Nullable<Text>,
         email -> Nullable<Text>,
         website -> Nullable<Text>,
+        hash -> Text,
         likes -> Nullable<Integer>,
         dislikes -> Nullable<Integer>,
         voters -> Text,


### PR DESCRIPTION
This PR will move identicon hashes to Sha224 since it's quick (compared to argon2) and we can also run it on the client side.

* [x] Crypto on front and back end
* [x] Save hash to DB
* [x] Integrate with comment API