### PR TITLE
Nested comments

### DIFF
--- a/oration.yaml
+++ b/oration.yaml
@@ -21,3 +21,7 @@ author:
   name:
   email:
   url:
+
+# Maximum thread nesting value. Depending on your layout, comments will get really bunched up and difficult
+# to read. So replies after a certain depth will no longer nest, but instead just respond to the current parent.
+nesting_limit: 6

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,8 @@ pub struct Config {
     pub salt: String,
     /// Blog Author to highlight as an authority in comments.
     pub author: Author,
+    /// Limit of thread nesting in comments.
+    pub nesting_limit: u32,
 }
 
 impl Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,6 +126,7 @@ fn new_comment<'a>(
                         form.email,
                         form.url,
                         &remote_addr.ip().to_string(),
+                        config.nesting_limit,
                     )
                     {
                         //Something went wrong, return a 500


### PR DESCRIPTION
This implements nested comments (#40) with a few caveats.

First, diesel doesn't accept `UNION ALL` or `WITH RECURSIVE` yet, but are tracking in diesel-rs/diesel#33 and diesel-rs/diesel#356 respectively. Because of this, the implementation of the depth search is in plain sql at the moment. 

Second, that plain sql is a bit skiddish to get around the current diesel version's raw sql complications. Once the next version is out we should move to using `sql_query`, but I see no point moving to the git master versions for a stop gap measure anyhow.

Third, there is probably more checks and functionality wanted in the future -- for example #49. Another feature may be that once we hit the nested limit, we should @mention the user we respond to automatically, once #28 is implemented.