### PR TITLE
Recursive comment counting

### DIFF
--- a/app/elm/Data/Comment.elm
+++ b/app/elm/Data/Comment.elm
@@ -1,4 +1,4 @@
-module Data.Comment exposing (Comment, Responses, decoder, encode, unwrapResponses)
+module Data.Comment exposing (Comment, Responses, count, decoder, encode, unwrapResponses)
 
 import Date exposing (Date)
 import Json.Decode as Decode exposing (Decoder)
@@ -28,6 +28,29 @@ unwrapResponses responses =
     case responses of
         Responses comments ->
             comments
+
+
+count : List Comment -> Int
+count comments =
+    let
+        responses =
+            List.concatMap (\c -> flatList c) comments
+    in
+    List.length responses
+
+
+flatList : Comment -> List Comment
+flatList root =
+    let
+        rest =
+            case root.children of
+                Just responseList ->
+                    List.concatMap (\child -> flatList child) <| unwrapResponses responseList
+
+                Nothing ->
+                    []
+    in
+    root :: rest
 
 
 

--- a/app/elm/Update.elm
+++ b/app/elm/Update.elm
@@ -1,5 +1,6 @@
 module Update exposing (subscriptions, update)
 
+import Data.Comment as Comment
 import Date
 import Http
 import Maybe.Extra exposing ((?))
@@ -131,7 +132,7 @@ update msg model =
         Comments (Ok result) ->
             let
                 count =
-                    List.length result
+                    Comment.count result
             in
             { model
                 | comments = result

--- a/app/elm/View.elm
+++ b/app/elm/View.elm
@@ -242,16 +242,11 @@ printComment comment now model =
         ]
 
 
-printResponses : Maybe Responses -> Maybe Date.Date -> Model -> Html Msg
+printResponses : Responses -> Maybe Date.Date -> Model -> Html Msg
 printResponses responses now model =
-    case responses of
-        Just responseList ->
-            ul [] <|
-                List.map (\c -> printComment c now model) <|
-                    unwrapResponses responseList
-
-        Nothing ->
-            nothing
+    ul [] <|
+        List.map (\c -> printComment c now model) <|
+            unwrapResponses responses
 
 
 replyForm : Int -> Maybe Int -> Model -> Html Msg

--- a/src/models/comments/mod.rs
+++ b/src/models/comments/mod.rs
@@ -281,12 +281,12 @@ pub struct NestedComment {
     /// Timestamp of creation.
     created: NaiveDateTime,
     /// Comment children.
-    children: Option<Vec<NestedComment>>,
+    children: Vec<NestedComment>,
 }
 
 impl NestedComment {
     /// Creates a new nested comment from a PrintedComment and a set of precalculated NestedComment children.
-    fn new(comment: &PrintedComment, children: Option<Vec<NestedComment>>) -> NestedComment {
+    fn new(comment: &PrintedComment, children: Vec<NestedComment>) -> NestedComment {
         NestedComment {
             id: comment.id,
             text: comment.text.to_owned(),
@@ -339,8 +339,8 @@ fn build_tree(graph: &DiGraphMap<i32, ()>, id: i32, comments: &[PrintedComment])
     let idx: usize = comments.iter().position(|c| c.id == id).unwrap();
 
     if !children.is_empty() {
-        NestedComment::new(&comments[idx], Some(children))
+        NestedComment::new(&comments[idx], children)
     } else {
-        NestedComment::new(&comments[idx], None)
+        NestedComment::new(&comments[idx], Vec::new())
     }
 }


### PR DESCRIPTION
Fixes #48 albeit poorly at the moment. This method flattens the comment list into a second list, then counts the elements. I think this is too much work and should be simplified. 

[This question on SO](https://stackoverflow.com/questions/47146239/counting-elements-in-recursive-type-alias-lists) will hopefully assist.