### PR TITLE
Move to Time.Date

### DIFF
--- a/app/elm/Data/Comment.elm
+++ b/app/elm/Data/Comment.elm
@@ -1,11 +1,11 @@
 module Data.Comment exposing (Comment, Responses(Responses), count, decoder, encode)
 
-import Date exposing (Date)
 import Json.Decode as Decode exposing (Decoder)
 import Json.Decode.Extra as DecodeExtra
 import Json.Decode.Pipeline exposing (decode, required)
 import Json.Encode as Encode exposing (Value)
 import Json.Encode.Extra as EncodeExtra
+import Time.Date exposing (Date)
 import Util exposing ((=>))
 
 
@@ -52,7 +52,7 @@ decoder =
         |> required "text" Decode.string
         |> required "author" (Decode.nullable Decode.string)
         |> required "hash" Decode.string
-        |> required "created" (Decode.nullable DecodeExtra.date)
+        |> required "created" (Decode.nullable decodeDate)
         |> required "id" Decode.int
         |> required "children" decodeResponses
 
@@ -60,6 +60,12 @@ decoder =
 decodeResponses : Decoder Responses
 decodeResponses =
     Decode.map Responses (Decode.list (Decode.lazy (\_ -> decoder)))
+
+
+decodeDate : Decoder Date
+decodeDate =
+    Decode.string
+        |> Decode.andThen (Time.Date.fromISO8601 >> DecodeExtra.fromResult)
 
 
 encode : Comment -> Value

--- a/app/elm/Data/Comment.elm
+++ b/app/elm/Data/Comment.elm
@@ -5,7 +5,7 @@ import Json.Decode.Extra as DecodeExtra
 import Json.Decode.Pipeline exposing (decode, required)
 import Json.Encode as Encode exposing (Value)
 import Json.Encode.Extra as EncodeExtra
-import Time.Date exposing (Date)
+import Time.DateTime exposing (DateTime)
 import Util exposing ((=>))
 
 
@@ -13,7 +13,7 @@ type alias Comment =
     { text : String
     , author : Maybe String
     , hash : String
-    , created : Maybe Date
+    , created : DateTime
     , id : Int
     , children : Responses
     }
@@ -52,7 +52,7 @@ decoder =
         |> required "text" Decode.string
         |> required "author" (Decode.nullable Decode.string)
         |> required "hash" Decode.string
-        |> required "created" (Decode.nullable decodeDate)
+        |> required "created" decodeDate
         |> required "id" Decode.int
         |> required "children" decodeResponses
 
@@ -62,10 +62,10 @@ decodeResponses =
     Decode.map Responses (Decode.list (Decode.lazy (\_ -> decoder)))
 
 
-decodeDate : Decoder Date
+decodeDate : Decoder DateTime
 decodeDate =
     Decode.string
-        |> Decode.andThen (Time.Date.fromISO8601 >> DecodeExtra.fromResult)
+        |> Decode.andThen (Time.DateTime.fromISO8601 >> DecodeExtra.fromResult)
 
 
 encode : Comment -> Value

--- a/app/elm/Main.elm
+++ b/app/elm/Main.elm
@@ -7,6 +7,7 @@ import Navigation
 import Request.Comment
 import Request.Init
 import Task
+import Time.DateTime exposing (dateTime, zero)
 import Update exposing (currentDate, subscriptions, update)
 import View exposing (view)
 
@@ -32,7 +33,7 @@ init location =
       , post = location
       , title = ""
       , httpResponse = ""
-      , now = Nothing
+      , now = dateTime zero
       , blogAuthor = ""
       }
     , initialise location

--- a/app/elm/Main.elm
+++ b/app/elm/Main.elm
@@ -1,6 +1,5 @@
 module Main exposing (main)
 
-import Date
 import Http
 import Models exposing (Model)
 import Msg exposing (Msg)
@@ -8,7 +7,7 @@ import Navigation
 import Request.Comment
 import Request.Init
 import Task
-import Update exposing (subscriptions, update)
+import Update exposing (currentDate, subscriptions, update)
 import View exposing (view)
 
 
@@ -54,5 +53,5 @@ initialise location =
     Cmd.batch
         [ Task.attempt Msg.Hashes loadHashes
         , Task.attempt Msg.Comments loadComments
-        , Task.perform Msg.NewDate Date.now
+        , Task.perform Msg.NewDate currentDate
         ]

--- a/app/elm/Models.elm
+++ b/app/elm/Models.elm
@@ -2,8 +2,8 @@ module Models exposing (Model)
 
 import Data.Comment exposing (Comment)
 import Data.User exposing (User)
-import Date exposing (Date)
 import Navigation exposing (Location)
+import Time.Date exposing (Date)
 
 
 type alias Model =

--- a/app/elm/Models.elm
+++ b/app/elm/Models.elm
@@ -15,6 +15,6 @@ type alias Model =
     , post : Location
     , title : String
     , httpResponse : String
-    , now : Maybe DateTime
+    , now : DateTime
     , blogAuthor : String
     }

--- a/app/elm/Models.elm
+++ b/app/elm/Models.elm
@@ -3,7 +3,7 @@ module Models exposing (Model)
 import Data.Comment exposing (Comment)
 import Data.User exposing (User)
 import Navigation exposing (Location)
-import Time.Date exposing (Date)
+import Time.DateTime exposing (DateTime)
 
 
 type alias Model =
@@ -15,6 +15,6 @@ type alias Model =
     , post : Location
     , title : String
     , httpResponse : String
-    , now : Maybe Date
+    , now : Maybe DateTime
     , blogAuthor : String
     }

--- a/app/elm/Msg.elm
+++ b/app/elm/Msg.elm
@@ -2,10 +2,10 @@ module Msg exposing (..)
 
 import Data.Comment exposing (Comment)
 import Data.Init exposing (Init)
-import Date exposing (Date)
 import Http
 import Navigation exposing (Location)
 import Time exposing (Time)
+import Time.Date exposing (Date)
 
 
 type Msg

--- a/app/elm/Msg.elm
+++ b/app/elm/Msg.elm
@@ -5,7 +5,7 @@ import Data.Init exposing (Init)
 import Http
 import Navigation exposing (Location)
 import Time exposing (Time)
-import Time.Date exposing (Date)
+import Time.DateTime exposing (DateTime)
 
 
 type Msg
@@ -24,5 +24,5 @@ type Msg
     | Hashes (Result Http.Error Init)
     | Comments (Result Http.Error (List Comment))
     | GetDate Time
-    | NewDate Date
+    | NewDate DateTime
     | CommentReply Int

--- a/app/elm/Time/DateTime/Distance.elm
+++ b/app/elm/Time/DateTime/Distance.elm
@@ -1,0 +1,236 @@
+module Time.DateTime.Distance exposing (inWords)
+
+import Time.DateTime as DT
+
+
+type Interval
+    = Second
+    | Minute
+    | Hour
+    | Day
+    | Month
+    | Year
+
+
+type Distance
+    = LessThanXSeconds Int
+    | HalfAMinute
+    | LessThanXMinutes Int
+    | XMinutes Int
+    | AboutXHours Int
+    | XDays Int
+    | AboutXMonths Int
+    | XMonths Int
+    | AboutXYears Int
+    | OverXYears Int
+    | AlmostXYears Int
+
+
+minutes_in_day : number
+minutes_in_day =
+    1440
+
+
+minutes_in_almost_two_days : number
+minutes_in_almost_two_days =
+    2520
+
+
+minutes_in_month : number
+minutes_in_month =
+    43200
+
+
+minutes_in_two_months : number
+minutes_in_two_months =
+    86400
+
+
+inWords : DT.DateTime -> DT.DateTime -> String
+inWords first second =
+    let
+        distance =
+            calculateDistance <| DT.delta first second
+    in
+    fromDistance distance
+
+
+upToOneMinute : Int -> Distance
+upToOneMinute seconds =
+    if seconds < 5 then
+        LessThanXSeconds 5
+    else if seconds < 10 then
+        LessThanXSeconds 10
+    else if seconds < 20 then
+        LessThanXSeconds 20
+    else if seconds < 40 then
+        HalfAMinute
+    else if seconds < 60 then
+        LessThanXMinutes 1
+    else
+        XMinutes 1
+
+
+upToOneDay : Int -> Distance
+upToOneDay minutes =
+    let
+        hours =
+            round <| toFloat minutes / 60
+    in
+    AboutXHours hours
+
+
+upToOneMonth : Int -> Distance
+upToOneMonth minutes =
+    let
+        days =
+            round <| toFloat minutes / minutes_in_day
+    in
+    XDays days
+
+
+upToTwoMonths : Int -> Distance
+upToTwoMonths minutes =
+    let
+        months =
+            round <| toFloat minutes / minutes_in_month
+    in
+    AboutXMonths months
+
+
+upToOneYear : Int -> Distance
+upToOneYear minutes =
+    let
+        nearestMonth =
+            round <| toFloat minutes / minutes_in_month
+    in
+    XMonths nearestMonth
+
+
+calculateDistance : DT.DateTimeDelta -> Distance
+calculateDistance delta =
+    let
+        seconds =
+            delta.seconds
+
+        minutes =
+            delta.minutes
+
+        months =
+            delta.months
+
+        years =
+            delta.years
+    in
+    if minutes == 0 then
+        LessThanXMinutes 1
+    else if minutes < 2 then
+        XMinutes minutes
+    else if minutes < 45 then
+        -- 2 mins up to 0.75 hrs
+        XMinutes minutes
+    else if minutes < 90 then
+        -- 0.75 hrs up to 1.5 hrs
+        AboutXHours 1
+    else if minutes < minutes_in_day then
+        -- 1.5 hrs up to 24 hrs
+        upToOneDay minutes
+    else if minutes < minutes_in_almost_two_days then
+        -- 1 day up to 1.75 days
+        XDays 1
+    else if minutes < minutes_in_month then
+        -- 1.75 days up to 30 days
+        upToOneMonth minutes
+    else if minutes < minutes_in_two_months then
+        -- 1 month up to 2 months
+        upToTwoMonths minutes
+    else if months < 12 then
+        -- 2 months up to 12 months
+        upToOneYear minutes
+    else
+        -- 1 year up to max Date
+        let
+            monthsSinceStartOfYear =
+                months % 12
+        in
+        if monthsSinceStartOfYear < 3 then
+            -- N years up to 1 years 3 months
+            AboutXYears years
+        else if monthsSinceStartOfYear < 9 then
+            -- N years 3 months up to N years 9 months
+            OverXYears years
+        else
+            -- N years 9 months up to N year 12 months
+            AlmostXYears <| years + 1
+
+
+fromDistance : Distance -> String
+fromDistance distance =
+    case distance of
+        LessThanXSeconds i ->
+            circa "less than" Second i
+
+        HalfAMinute ->
+            "half a minute"
+
+        LessThanXMinutes i ->
+            circa "less than" Minute i
+
+        XMinutes i ->
+            exact Minute i
+
+        AboutXHours i ->
+            circa "about" Hour i
+
+        XDays i ->
+            exact Day i
+
+        AboutXMonths i ->
+            circa "about" Month i
+
+        XMonths i ->
+            exact Month i
+
+        AboutXYears i ->
+            circa "about" Year i
+
+        OverXYears i ->
+            circa "over" Year i
+
+        AlmostXYears i ->
+            circa "almost" Year i
+
+
+formatInterval : Interval -> String
+formatInterval =
+    String.toLower << toString
+
+
+singular : Interval -> String
+singular interval =
+    case interval of
+        Minute ->
+            "a " ++ formatInterval interval
+
+        _ ->
+            "1 " ++ formatInterval interval
+
+
+circa : String -> Interval -> Int -> String
+circa prefix interval i =
+    case i of
+        1 ->
+            prefix ++ " " ++ singular interval ++ " ago"
+
+        _ ->
+            prefix ++ " " ++ toString i ++ " " ++ formatInterval interval ++ "s ago"
+
+
+exact : Interval -> Int -> String
+exact interval i =
+    case i of
+        1 ->
+            "1 " ++ formatInterval interval ++ " ago"
+
+        _ ->
+            toString i ++ " " ++ formatInterval interval ++ "s ago"

--- a/app/elm/Update.elm
+++ b/app/elm/Update.elm
@@ -1,7 +1,6 @@
 module Update exposing (currentDate, subscriptions, update)
 
 import Data.Comment as Comment
-import Date as CoreDate
 import Http
 import Maybe.Extra exposing ((?))
 import Models exposing (Model)
@@ -148,7 +147,7 @@ update msg model =
             model ! [ Task.perform NewDate currentDate ]
 
         NewDate date ->
-            { model | now = Just date } ! []
+            { model | now = date } ! []
 
         CommentReply id ->
             let
@@ -188,53 +187,9 @@ dumbDecode val =
 
 currentDate : Task.Task x DateTime
 currentDate =
-    CoreDate.now |> Task.map coreDateToDate
+    Time.now |> Task.map timeToDateTime
 
 
-coreDateToDate : CoreDate.Date -> DateTime
-coreDateToDate core =
-    let
-        convert =
-            ( CoreDate.year core, coreMonthToInt <| CoreDate.month core, CoreDate.day core, CoreDate.hour core, CoreDate.minute core, CoreDate.second core, CoreDate.millisecond core )
-    in
-    Time.DateTime.fromTuple convert
-
-
-coreMonthToInt : CoreDate.Month -> Int
-coreMonthToInt month =
-    case month of
-        CoreDate.Jan ->
-            1
-
-        CoreDate.Feb ->
-            2
-
-        CoreDate.Mar ->
-            3
-
-        CoreDate.Apr ->
-            4
-
-        CoreDate.May ->
-            5
-
-        CoreDate.Jun ->
-            6
-
-        CoreDate.Jul ->
-            7
-
-        CoreDate.Aug ->
-            8
-
-        CoreDate.Sep ->
-            9
-
-        CoreDate.Oct ->
-            10
-
-        CoreDate.Nov ->
-            11
-
-        CoreDate.Dec ->
-            12
+timeToDateTime : Time.Time -> DateTime
+timeToDateTime =
+    Time.DateTime.fromTimestamp

--- a/app/elm/Update.elm
+++ b/app/elm/Update.elm
@@ -10,7 +10,7 @@ import Ports
 import Request.Comment
 import Task
 import Time exposing (Time, minute)
-import Time.Date exposing (Date)
+import Time.DateTime exposing (DateTime)
 import Util exposing (stringToMaybe)
 
 
@@ -186,18 +186,18 @@ dumbDecode val =
         False
 
 
-currentDate : Task.Task x Date
+currentDate : Task.Task x DateTime
 currentDate =
     CoreDate.now |> Task.map coreDateToDate
 
 
-coreDateToDate : CoreDate.Date -> Date
+coreDateToDate : CoreDate.Date -> DateTime
 coreDateToDate core =
     let
         convert =
-            ( CoreDate.year core, coreMonthToInt <| CoreDate.month core, CoreDate.day core )
+            ( CoreDate.year core, coreMonthToInt <| CoreDate.month core, CoreDate.day core, CoreDate.hour core, CoreDate.minute core, CoreDate.second core, CoreDate.millisecond core )
     in
-    Time.Date.fromTuple convert
+    Time.DateTime.fromTuple convert
 
 
 coreMonthToInt : CoreDate.Month -> Int

--- a/app/elm/Update.elm
+++ b/app/elm/Update.elm
@@ -1,7 +1,7 @@
-module Update exposing (subscriptions, update)
+module Update exposing (currentDate, subscriptions, update)
 
 import Data.Comment as Comment
-import Date
+import Date as CoreDate
 import Http
 import Maybe.Extra exposing ((?))
 import Models exposing (Model)
@@ -10,6 +10,7 @@ import Ports
 import Request.Comment
 import Task
 import Time exposing (Time, minute)
+import Time.Date exposing (Date)
 import Util exposing (stringToMaybe)
 
 
@@ -144,7 +145,7 @@ update msg model =
             model ! []
 
         GetDate _ ->
-            model ! [ Task.perform NewDate Date.now ]
+            model ! [ Task.perform NewDate currentDate ]
 
         NewDate date ->
             { model | now = Just date } ! []
@@ -183,3 +184,57 @@ dumbDecode val =
         True
     else
         False
+
+
+currentDate : Task.Task x Date
+currentDate =
+    CoreDate.now |> Task.map coreDateToDate
+
+
+coreDateToDate : CoreDate.Date -> Date
+coreDateToDate core =
+    let
+        convert =
+            ( CoreDate.year core, coreMonthToInt <| CoreDate.month core, CoreDate.day core )
+    in
+    Time.Date.fromTuple convert
+
+
+coreMonthToInt : CoreDate.Month -> Int
+coreMonthToInt month =
+    case month of
+        CoreDate.Jan ->
+            1
+
+        CoreDate.Feb ->
+            2
+
+        CoreDate.Mar ->
+            3
+
+        CoreDate.Apr ->
+            4
+
+        CoreDate.May ->
+            5
+
+        CoreDate.Jun ->
+            6
+
+        CoreDate.Jul ->
+            7
+
+        CoreDate.Aug ->
+            8
+
+        CoreDate.Sep ->
+            9
+
+        CoreDate.Oct ->
+            10
+
+        CoreDate.Nov ->
+            11
+
+        CoreDate.Dec ->
+            12

--- a/app/elm/View.elm
+++ b/app/elm/View.elm
@@ -12,7 +12,7 @@ import Maybe.Extra exposing ((?), isJust, isNothing)
 import Models exposing (Model)
 import Msg exposing (Msg(..))
 import Style
-import Time.Date exposing (Date)
+import Time.DateTime exposing (DateTime)
 import Util exposing (nothing)
 
 
@@ -164,7 +164,7 @@ getIdentity user =
 {- We work in UTC, so offset the users time so we can compare dates -}
 
 
-offsetNow : Maybe Date -> Maybe Date
+offsetNow : Maybe DateTime -> Maybe DateTime
 offsetNow now =
     now
 
@@ -191,25 +191,14 @@ printComments model =
 {- Format a single comment -}
 
 
-printComment : Comment -> Maybe Date -> Model -> Html Msg
+printComment : Comment -> Maybe DateTime -> Model -> Html Msg
 printComment comment now model =
     let
         author =
             comment.author ? "Anonymous"
 
         created =
-            --TODO: Can this be chained?
-            case comment.created of
-                Just val ->
-                    Time.Date.toISO8601 val
-
-                --case now of
-                --Just time ->
-                --inWordsWithConfig wordsConfig time val
-                --Nothing ->
-                --""
-                Nothing ->
-                    ""
+            Time.DateTime.toISO8601 comment.created
 
         id =
             toString comment.id
@@ -238,7 +227,7 @@ printComment comment now model =
         ]
 
 
-printResponses : Responses -> Maybe Date -> Model -> Html Msg
+printResponses : Responses -> Maybe DateTime -> Model -> Html Msg
 printResponses (Responses responses) now model =
     ul [] <|
         List.map (\c -> printComment c now model) responses

--- a/app/elm/View.elm
+++ b/app/elm/View.elm
@@ -164,7 +164,7 @@ getIdentity user =
 {- We work in UTC, so offset the users time so we can compare dates -}
 
 
-offsetNow : Maybe DateTime -> Maybe DateTime
+offsetNow : DateTime -> DateTime
 offsetNow now =
     now
 
@@ -191,14 +191,17 @@ printComments model =
 {- Format a single comment -}
 
 
-printComment : Comment -> Maybe DateTime -> Model -> Html Msg
+printComment : Comment -> DateTime -> Model -> Html Msg
 printComment comment now model =
     let
         author =
             comment.author ? "Anonymous"
 
+        now_ =
+            Time.DateTime.toISO8601 now
+
         created =
-            Time.DateTime.toISO8601 comment.created
+            Time.DateTime.toISO8601 comment.created ++ " " ++ now_
 
         id =
             toString comment.id
@@ -227,7 +230,7 @@ printComment comment now model =
         ]
 
 
-printResponses : Responses -> Maybe DateTime -> Model -> Html Msg
+printResponses : Responses -> DateTime -> Model -> Html Msg
 printResponses (Responses responses) now model =
     ul [] <|
         List.map (\c -> printComment c now model) responses

--- a/app/elm/View.elm
+++ b/app/elm/View.elm
@@ -3,12 +3,6 @@ module View exposing (view)
 import Crypto.Hash
 import Data.Comment exposing (Comment, Responses(Responses))
 import Data.User exposing (User)
-import Date
-import Date.Distance exposing (defaultConfig, inWordsWithConfig)
-import Date.Distance.I18n.En as English
-import Date.Distance.Types exposing (Config)
-import Date.Extra.Create exposing (getTimezoneOffset)
-import Date.Extra.Period as Period exposing (Period(..))
 import Html exposing (..)
 import Html.Attributes exposing (autocomplete, checked, cols, defaultValue, disabled, for, method, minlength, name, placeholder, rows, type_, value)
 import Html.Events exposing (onClick, onInput, onSubmit)
@@ -18,6 +12,7 @@ import Maybe.Extra exposing ((?), isJust, isNothing)
 import Models exposing (Model)
 import Msg exposing (Msg(..))
 import Style
+import Time.Date exposing (Date)
 import Util exposing (nothing)
 
 
@@ -169,16 +164,17 @@ getIdentity user =
 {- We work in UTC, so offset the users time so we can compare dates -}
 
 
-offsetNow : Maybe Date.Date -> Maybe Date.Date
+offsetNow : Maybe Date -> Maybe Date
 offsetNow now =
-    let
-        offsetMinutes =
-            Maybe.map getTimezoneOffset now
-    in
-    Maybe.map (\d -> Period.add Period.Minute (offsetMinutes ? 0) d) now
+    now
 
 
 
+-- let
+--    offsetMinutes =
+--       Maybe.map getTimezoneOffset now
+--  in
+-- Maybe.map (\d -> Period.add Period.Minute (offsetMinutes ? 0) d) now
 {- Format a list of comments -}
 
 
@@ -195,7 +191,7 @@ printComments model =
 {- Format a single comment -}
 
 
-printComment : Comment -> Maybe Date.Date -> Model -> Html Msg
+printComment : Comment -> Maybe Date -> Model -> Html Msg
 printComment comment now model =
     let
         author =
@@ -205,13 +201,13 @@ printComment comment now model =
             --TODO: Can this be chained?
             case comment.created of
                 Just val ->
-                    case now of
-                        Just time ->
-                            inWordsWithConfig wordsConfig time val
+                    Time.Date.toISO8601 val
 
-                        Nothing ->
-                            ""
-
+                --case now of
+                --Just time ->
+                --inWordsWithConfig wordsConfig time val
+                --Nothing ->
+                --""
                 Nothing ->
                     ""
 
@@ -242,7 +238,7 @@ printComment comment now model =
         ]
 
 
-printResponses : Responses -> Maybe Date.Date -> Model -> Html Msg
+printResponses : Responses -> Maybe Date -> Model -> Html Msg
 printResponses (Responses responses) now model =
     ul [] <|
         List.map (\c -> printComment c now model) responses
@@ -259,18 +255,3 @@ replyForm id parent model =
 
         Nothing ->
             nothing
-
-
-
-{- We want to add a suffix onto our word distances.
-   This is how you do that. Not very nice, but we can extend the locale portion later this way
--}
-
-
-wordsConfig : Config
-wordsConfig =
-    let
-        localeWithSuffix =
-            English.locale { addSuffix = True }
-    in
-    { defaultConfig | locale = localeWithSuffix }

--- a/app/elm/View.elm
+++ b/app/elm/View.elm
@@ -12,7 +12,7 @@ import Maybe.Extra exposing ((?), isJust, isNothing)
 import Models exposing (Model)
 import Msg exposing (Msg(..))
 import Style
-import Time.DateTime exposing (DateTime)
+import Time.DateTime.Distance exposing (inWords)
 import Util exposing (nothing)
 
 
@@ -161,47 +161,26 @@ getIdentity user =
 
 
 
-{- We work in UTC, so offset the users time so we can compare dates -}
-
-
-offsetNow : DateTime -> DateTime
-offsetNow now =
-    now
-
-
-
--- let
---    offsetMinutes =
---       Maybe.map getTimezoneOffset now
---  in
--- Maybe.map (\d -> Period.add Period.Minute (offsetMinutes ? 0) d) now
 {- Format a list of comments -}
 
 
 printComments : Model -> List (Html Msg)
 printComments model =
-    let
-        utcNow =
-            offsetNow model.now
-    in
-    List.map (\c -> printComment c utcNow model) model.comments
+    List.map (\c -> printComment c model) model.comments
 
 
 
 {- Format a single comment -}
 
 
-printComment : Comment -> DateTime -> Model -> Html Msg
-printComment comment now model =
+printComment : Comment -> Model -> Html Msg
+printComment comment model =
     let
         author =
             comment.author ? "Anonymous"
 
-        now_ =
-            Time.DateTime.toISO8601 now
-
         created =
-            Time.DateTime.toISO8601 comment.created ++ " " ++ now_
+            inWords model.now comment.created
 
         id =
             toString comment.id
@@ -226,14 +205,14 @@ printComment comment now model =
         , span [ class [ Style.Content ] ] <| Markdown.toHtml Nothing comment.text
         , button [ onClick (CommentReply comment.id), class [ Style.Reply ] ] [ text buttonText ]
         , replyForm comment.id model.parent model
-        , printResponses comment.children now model
+        , printResponses comment.children model
         ]
 
 
-printResponses : Responses -> DateTime -> Model -> Html Msg
-printResponses (Responses responses) now model =
+printResponses : Responses -> Model -> Html Msg
+printResponses (Responses responses) model =
     ul [] <|
-        List.map (\c -> printComment c now model) responses
+        List.map (\c -> printComment c model) responses
 
 
 replyForm : Int -> Maybe Int -> Model -> Html Msg

--- a/app/elm/elm-package.json
+++ b/app/elm/elm-package.json
@@ -11,6 +11,7 @@
     "dependencies": {
         "NoRedInk/elm-decode-pipeline": "3.0.0 <= v < 4.0.0",
         "alpacaaa/elm-date-distance": "1.1.0 <= v < 2.0.0",
+        "elm-community/elm-time": "1.0.11 <= v < 2.0.0",
         "elm-community/json-extra": "2.3.0 <= v < 3.0.0",
         "elm-community/maybe-extra": "4.0.0 <= v < 5.0.0",
         "elm-lang/core": "5.1.1 <= v < 6.0.0",

--- a/app/elm/tests/Helpers/Dates.elm
+++ b/app/elm/tests/Helpers/Dates.elm
@@ -1,0 +1,23 @@
+module Helpers.Dates exposing (..)
+
+import Fuzz exposing (Fuzzer, int, intRange)
+import Time.Date exposing (Date, addDays, date, isLeapYear)
+
+
+dateForYear : Int -> Fuzzer Date
+dateForYear year =
+    let
+        daysUpper =
+            if isLeapYear year then
+                365
+            else
+                364
+    in
+    intRange 0 daysUpper
+        |> Fuzz.map (\days -> addDays days (date year 1 1))
+
+
+dateWithinYearRange : Int -> Int -> Fuzzer Date
+dateWithinYearRange lower upper =
+    intRange lower upper
+        |> Fuzz.andThen (\year -> dateForYear year)

--- a/app/elm/tests/Helpers/Dates.elm
+++ b/app/elm/tests/Helpers/Dates.elm
@@ -1,10 +1,11 @@
 module Helpers.Dates exposing (..)
 
 import Fuzz exposing (Fuzzer, int, intRange)
-import Time.Date exposing (Date, addDays, date, isLeapYear)
+import Time.Date exposing (isLeapYear)
+import Time.DateTime exposing (DateTime, addDays, dateTime, zero)
 
 
-dateForYear : Int -> Fuzzer Date
+dateForYear : Int -> Fuzzer DateTime
 dateForYear year =
     let
         daysUpper =
@@ -14,10 +15,10 @@ dateForYear year =
                 364
     in
     intRange 0 daysUpper
-        |> Fuzz.map (\days -> addDays days (date year 1 1))
+        |> Fuzz.map (\days -> addDays days (dateTime { zero | year = year }))
 
 
-dateWithinYearRange : Int -> Int -> Fuzzer Date
+dateWithinYearRange : Int -> Int -> Fuzzer DateTime
 dateWithinYearRange lower upper =
     intRange lower upper
         |> Fuzz.andThen (\year -> dateForYear year)

--- a/app/elm/tests/Tests.elm
+++ b/app/elm/tests/Tests.elm
@@ -1,9 +1,54 @@
 module Tests exposing (..)
 
+import Data.Comment exposing (Comment, Responses(Responses))
+import Data.User exposing (User)
 import Expect exposing (..)
-import Fuzz exposing (Fuzzer, int, list, maybe, string, tuple)
+import Fuzz exposing (Fuzzer, bool, int, list, maybe, string, tuple)
+import Helpers.Dates exposing (dateWithinYearRange)
+import Json.Decode as Decode
+import Json.Encode as Encode
 import Test exposing (..)
+import Time.Date exposing (Date)
 import Util exposing (..)
+
+
+user : Fuzzer User
+user =
+    Fuzz.map5 User
+        (maybe string)
+        (maybe string)
+        (maybe string)
+        (maybe string)
+        bool
+
+
+
+{-
+   commentEncode : Fuzzer Comment
+   commentEncode =
+       Fuzz.map3 Comment
+           string
+           (maybe string)
+           string
+
+
+
+      commentDecode : Fuzzer Comment
+      commentDecode =
+          Fuzz.map5 Comment
+              string
+              (maybe string)
+              string
+              (maybe (dateNear 2017))
+              int
+              |> Fuzz.andMap (list (Fuzz.constant []))
+
+-}
+
+
+dateNear : Int -> Fuzzer Date
+dateNear y =
+    dateWithinYearRange (y - 2) (y + 2)
 
 
 all : Test
@@ -23,4 +68,21 @@ all =
                     pair first second
                         |> Expect.equal ( first, second )
             ]
+        , describe "Data.User"
+            [ fuzz user "Serialization round trip" <|
+                \thisUser ->
+                    thisUser
+                        |> Data.User.encode
+                        |> Decode.decodeValue Data.User.decoder
+                        |> Expect.equal (Ok thisUser)
+            ]
+
+        {- , describe "Data.Comment"
+           [ fuzz commentDecode "Serialization Decode" <|
+               \thisComment ->
+                   thisComment
+                       |> Decode.decodeValue Data.Comment.decoder
+                       |> Expect.equal (Ok thisComment)
+                       ]
+        -}
         ]

--- a/app/elm/tests/Tests.elm
+++ b/app/elm/tests/Tests.elm
@@ -8,7 +8,7 @@ import Helpers.Dates exposing (dateWithinYearRange)
 import Json.Decode as Decode
 import Json.Encode as Encode
 import Test exposing (..)
-import Time.Date exposing (Date)
+import Time.DateTime exposing (DateTime)
 import Util exposing (..)
 
 
@@ -46,7 +46,7 @@ user =
 -}
 
 
-dateNear : Int -> Fuzzer Date
+dateNear : Int -> Fuzzer DateTime
 dateNear y =
     dateWithinYearRange (y - 2) (y + 2)
 

--- a/app/elm/tests/elm-package.json
+++ b/app/elm/tests/elm-package.json
@@ -25,7 +25,11 @@
         "lukewestby/elm-http-builder": "5.1.0 <= v < 6.0.0",
         "pablohirafuji/elm-markdown": "2.0.4 <= v < 3.0.0",
         "pukkamustard/elm-identicon": "3.0.0 <= v < 4.0.0",
-        "rluiten/elm-date-extra": "9.2.0 <= v < 10.0.0"
+        "rluiten/elm-date-extra": "9.2.0 <= v < 10.0.0",
+        "rtfeldman/elm-css": "11.2.0 <= v < 12.0.0",
+        "rtfeldman/elm-css-helpers": "2.1.0 <= v < 3.0.0",
+        "scottcorgan/elm-css-normalize": "1.1.9 <= v < 2.0.0",
+        "elm-community/elm-time": "1.0.11 <= v < 2.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/src/models/comments/mod.rs
+++ b/src/models/comments/mod.rs
@@ -3,7 +3,7 @@ use diesel::prelude::*;
 use diesel::sqlite::SqliteConnection;
 use diesel::types::{Integer, Text};
 use diesel::expression::dsl::sql;
-use chrono::{NaiveDateTime, Utc};
+use chrono::{DateTime, NaiveDateTime, Utc};
 use crypto::digest::Digest;
 use crypto::sha2::Sha224;
 use itertools::join;
@@ -279,7 +279,7 @@ pub struct NestedComment {
     /// Commentors indentifier.
     hash: String,
     /// Timestamp of creation.
-    created: NaiveDateTime,
+    created: DateTime<Utc>,
     /// Comment children.
     children: Vec<NestedComment>,
 }
@@ -287,12 +287,13 @@ pub struct NestedComment {
 impl NestedComment {
     /// Creates a new nested comment from a PrintedComment and a set of precalculated NestedComment children.
     fn new(comment: &PrintedComment, children: Vec<NestedComment>) -> NestedComment {
+        let date_time = DateTime::<Utc>::from_utc(comment.created, Utc);
         NestedComment {
             id: comment.id,
             text: comment.text.to_owned(),
             author: comment.author.to_owned(),
             hash: comment.hash.to_owned(),
-            created: comment.created,
+            created: date_time,
             children: children,
         }
     }


### PR DESCRIPTION
From the looks of it, `Core.Date` [isn't going to exist](https://github.com/elm-lang/core/commit/a892fdf705f83523752c5469384e9880fbdfe3b1#diff-25d902c24283ab8cfbac54dfa101ad31) soon enough and effort is moving to [elm-community/elm-time](https://github.com/elm-community/elm-time).

This is going to break a lot of things, so better start on it now.

Currently this drops the fuzzy time distances, any timezone offset and all time data, but gets us `Date.now` as a `Time.Date` and displays the `Date` for each comment. We still need to extend the values to `DateTime`s or even `ZonedDateTime`s if warranted, fix the UTCoffsets and probably re-implement the fuzzy time distances. The last portion might be useful to actually be a new package.