### PR TITLE
Add Elm to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 matrix:
   include:
     - language: rust
-      rust:
-        - nightly
-      allow_failures:
-        - rust: nightly
+      rust: nightly
       cache: cargo
       sudo: true
       dist: trusty
@@ -34,8 +31,7 @@ matrix:
               echo "Uploaded documentation"
             fi
     - language: node_js
-      node_js:
-        - "node"
+      node_js: node
       sudo: true
       before_install:
         - "npm install -g elm@0.18"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,13 @@ matrix:
       node_js: node
       sudo: true
       before_install:
-        - "npm install -g elm@0.18"
+        - "npm install -g elm@0.18 elm-test elm-css"
       cache:
         directories:
           - app/elm/elm-stuff/build-artifacts
+          - app/elm/tests/elm-stuff/build-artifacts
       script:
-        - cd app/elm && elm-make --yes
+        - cd app/elm
+        - elm-make --yes
+        - elm-css Stylesheets.elm
+        - elm-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,23 @@
-language: rust
+matrix:
+  include:
+    - language: rust
+      rust:
+        - nightly
+    - language: node_js
+      node_js: 
+        - "node"
+  allow_failures:
+    - rust: nightly
 cache: cargo
 sudo: true
 dist: trusty
 os: linux
-rust:
-  - nightly
-matrix:
-  allow_failures:
-    - rust: nightly
 addons:
   apt:
     packages:
       - sqlite3
+before_install:
+  - "npm install elm@0.18"
 before_script:
   - ( cargo install diesel_cli --no-default-features --features sqlite || true )
   - export PATH=$PATH:~/.cargo/bin
@@ -21,6 +27,7 @@ before_script:
 script:
   - cargo build
   - cargo test
+  - elm make --yes
 after_success:
   # Upload docs
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,4 +42,4 @@ matrix:
         directories:
           - app/elm/elm-stuff/build-artifacts
       script:
-        - cd app/elm && elm make --yes
+        - cd app/elm && elm-make --yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,40 +3,40 @@ matrix:
     - language: rust
       rust:
         - nightly
+      allow_failures:
+        - rust: nightly
+      cache: cargo
+      sudo: true
+      dist: trusty
+      os: linux
+      addons:
+        apt:
+          packages:
+            - sqlite3
+      before_script:
+        - ( cargo install diesel_cli --no-default-features --features sqlite || true )
+        - export PATH=$PATH:~/.cargo/bin
+        - echo "DATABASE_URL=oration.db" > .env
+        - diesel migration run
+        - cargo update
+      script:
+        - cargo build
+        - cargo test
+      after_success:
+        # Upload docs
+        - |
+            if [[ "$TRAVIS_PULL_REQUEST" = "false" && "$TRAVIS_BRANCH" == "master" ]]; then
+              cargo rustdoc -- --no-defaults --passes collapse-docs --passes unindent-comments --passes strip-priv-imports &&
+              cp logo/logo_wbl.svg target/doc/ &&
+              echo "<meta http-equiv=refresh content=0;url=oration/index.html>" > target/doc/index.html &&
+              git clone https://github.com/davisp/ghp-import.git &&
+              ./ghp-import/ghp_import.py -n -p -f -m "Documentation upload" -r https://"$GH_TOKEN"@github.com/"$TRAVIS_REPO_SLUG.git" target/doc &&
+              echo "Uploaded documentation"
+            fi
     - language: node_js
       node_js: 
         - "node"
-  allow_failures:
-    - rust: nightly
-cache: cargo
-sudo: true
-dist: trusty
-os: linux
-addons:
-  apt:
-    packages:
-      - sqlite3
-before_install:
-  - "npm install elm@0.18"
-before_script:
-  - ( cargo install diesel_cli --no-default-features --features sqlite || true )
-  - export PATH=$PATH:~/.cargo/bin
-  - echo "DATABASE_URL=oration.db" > .env
-  - diesel migration run
-  - cargo update
-script:
-  - cargo build
-  - cargo test
-  - elm make --yes
-after_success:
-  # Upload docs
-  - |
-      if [[ "$TRAVIS_PULL_REQUEST" = "false" && "$TRAVIS_BRANCH" == "master" ]]; then
-        cargo rustdoc -- --no-defaults --passes collapse-docs --passes unindent-comments --passes strip-priv-imports &&
-        cp logo/logo_wbl.svg target/doc/ &&
-        echo "<meta http-equiv=refresh content=0;url=oration/index.html>" > target/doc/index.html &&
-        git clone https://github.com/davisp/ghp-import.git &&
-        ./ghp-import/ghp_import.py -n -p -f -m "Documentation upload" -r https://"$GH_TOKEN"@github.com/"$TRAVIS_REPO_SLUG.git" target/doc &&
-        echo "Uploaded documentation"
-      fi
-
+      before_install:
+        - "npm install elm@0.18"
+      script:
+        - elm make --yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,9 @@ matrix:
     - language: node_js
       node_js:
         - "node"
+      sudo: true
       before_install:
-        - "npm install elm@0.18"
+        - "npm install -g elm@0.18"
       cache:
         directories:
           - app/elm/elm-stuff/build-artifacts

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,12 @@ matrix:
               echo "Uploaded documentation"
             fi
     - language: node_js
-      node_js: 
+      node_js:
         - "node"
       before_install:
         - "npm install elm@0.18"
+      cache:
+        directories:
+          - app/elm/elm-stuff/build-artifacts
       script:
-        - elm make --yes
+        - cd app/elm && elm make --yes


### PR DESCRIPTION
Sets up two separate testing facilities in travis, such that the elm builds and tests can be run along side the rust ones.