### PR TITLE
Implement Katex

### DIFF
--- a/app/elm/Util.elm
+++ b/app/elm/Util.elm
@@ -49,14 +49,14 @@ nothing =
 -}
 
 
-parseMath : String -> String
+parseMath : List String -> List String
 parseMath =
-    parseInline
+    parseInline >> parseDisplay
 
 
-parseDisplay : String -> String
+parseDisplay : List String -> List String
 parseDisplay =
-    replace Regex.All (regex "^\\$\\$(.+?)\\$\\$") separateDisplay
+    List.map (replace (Regex.AtMost 1) (regex "^\\${2}(.+?)\\${2}") separateDisplay)
 
 
 separateDisplay : Regex.Match -> String
@@ -68,9 +68,9 @@ separateDisplay match =
     Katex.print (display result)
 
 
-parseInline : String -> String
+parseInline : List String -> List String
 parseInline =
-    replace Regex.All (regex "\\$(?!\\$)(.+?)\\$(?!\\$)") separateInline
+    List.map (replace Regex.All (regex "\\$([^\\$]+?)\\$(?!\\$)") separateInline)
 
 
 separateInline : Regex.Match -> String

--- a/app/elm/Util.elm
+++ b/app/elm/Util.elm
@@ -1,6 +1,9 @@
-module Util exposing ((=>), nothing, pair, stringToMaybe)
+module Util exposing ((=>), nothing, pair, parseMath, stringToMaybe)
 
 import Html exposing (Html, text)
+import Katex exposing (Latex, display, human, inline)
+import Maybe.Extra exposing ((?))
+import Regex exposing (regex, replace)
 
 
 (=>) : a -> b -> ( a, b )
@@ -37,3 +40,43 @@ stringToMaybe val =
 nothing : Html msg
 nothing =
     text ""
+
+
+
+{- Identify math strings and use Katex to parse them.
+   Note, we still return a string here rather than HTML, since this
+   will go through the markdown parser next, which handles raw HTML.
+-}
+
+
+parseMath : String -> String
+parseMath =
+    parseInline
+
+
+parseDisplay : String -> String
+parseDisplay =
+    replace Regex.All (regex "^\\$\\$(.+?)\\$\\$") separateDisplay
+
+
+separateDisplay : Regex.Match -> String
+separateDisplay match =
+    let
+        result =
+            (List.head match.submatches ? Just "") ? ""
+    in
+    Katex.print (display result)
+
+
+parseInline : String -> String
+parseInline =
+    replace Regex.All (regex "\\$(?!\\$)(.+?)\\$(?!\\$)") separateInline
+
+
+separateInline : Regex.Match -> String
+separateInline match =
+    let
+        result =
+            (List.head match.submatches ? Just "") ? ""
+    in
+    Katex.print (inline result)

--- a/app/elm/View.elm
+++ b/app/elm/View.elm
@@ -13,7 +13,7 @@ import Models exposing (Model)
 import Msg exposing (Msg(..))
 import Style
 import Time.DateTime.Distance exposing (inWords)
-import Util exposing (nothing)
+import Util exposing (nothing, parseMath)
 
 
 {- Sync up stylsheets -}
@@ -27,7 +27,7 @@ view : Model -> Html Msg
 view model =
     let
         markdown =
-            markdownContent model.comment model.user.preview
+            markdownContent model.comment model.user.preview |> parseMath
 
         count =
             toString model.count
@@ -128,7 +128,7 @@ setButtonDisabled comment =
 
 
 
-{- Renders comments to markdown -}
+{- Markdown preview box information -}
 
 
 markdownContent : String -> Bool -> String

--- a/app/elm/View.elm
+++ b/app/elm/View.elm
@@ -13,7 +13,7 @@ import Models exposing (Model)
 import Msg exposing (Msg(..))
 import Style
 import Time.DateTime.Distance exposing (inWords)
-import Util exposing (nothing, parseMath)
+import Util exposing (nothing, parseMath, viewKatex)
 
 
 {- Sync up stylsheets -}
@@ -28,10 +28,8 @@ view model =
     let
         markdown =
             markdownContent model.comment model.user.preview
-                |> String.lines
-                |> parseMath
-                >> String.join "\n"
 
+        -- >> String.join "\n"
         count =
             toString model.count
                 ++ (if model.count /= 1 then
@@ -46,6 +44,7 @@ view model =
         , div [ id Style.OrationDebug ] [ text model.httpResponse ]
         , div [ id Style.OrationCommentPreview ] <|
             Markdown.toHtml Nothing markdown
+        , div [] <| parseMath markdown
         , ul [ id Style.OrationComments ] <| printComments model
         ]
 
@@ -199,13 +198,16 @@ printComment comment model =
                 [ Style.Comment, Style.BlogAuthor ]
             else
                 [ Style.Comment ]
+
+        markedUpComment =
+            comment.text
     in
     li [ name ("comment-" ++ id), class commentStyle ]
         [ span [ class [ Style.Identicon ] ] [ identicon "25px" comment.hash ]
         , printAuthor author
         , span [ class [ Style.Spacer ] ] [ text "•" ]
         , span [ class [ Style.Date ] ] [ text created ]
-        , span [ class [ Style.Content ] ] <| Markdown.toHtml Nothing comment.text
+        , span [ class [ Style.Content ] ] <| parseMath markedUpComment
         , button [ onClick (CommentReply comment.id), class [ Style.Reply ] ] [ text buttonText ]
         , replyForm comment.id model.parent model
         , printResponses comment.children model

--- a/app/elm/View.elm
+++ b/app/elm/View.elm
@@ -27,7 +27,10 @@ view : Model -> Html Msg
 view model =
     let
         markdown =
-            markdownContent model.comment model.user.preview |> parseMath
+            markdownContent model.comment model.user.preview
+                |> String.lines
+                |> parseMath
+                >> String.join "\n"
 
         count =
             toString model.count

--- a/app/elm/elm-package.json
+++ b/app/elm/elm-package.json
@@ -24,7 +24,8 @@
         "pukkamustard/elm-identicon": "3.0.0 <= v < 4.0.0",
         "rtfeldman/elm-css": "11.2.0 <= v < 12.0.0",
         "rtfeldman/elm-css-helpers": "2.1.0 <= v < 3.0.0",
-        "scottcorgan/elm-css-normalize": "1.1.9 <= v < 2.0.0"
+        "scottcorgan/elm-css-normalize": "1.1.9 <= v < 2.0.0",
+        "yotamDvir/elm-katex": "2.0.0 <= v < 3.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -39,4 +39,13 @@ if (elmDiv) {
     app.ports.setPreview.subscribe(function(state) {
         localStorage.setItem('preview', state);
     });
+
+    setTimeout(function () {
+        renderMathInElement(document.body,
+            {delimiters:
+                [{left: "$begin-inline$", right: "$end-inline$", display: false},
+                 {left: "$begin-display$", right: "$end-display$", display: true}]
+            });
+    }, 0);
 }
+

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -7,9 +7,10 @@
   <title>Oration - Test Index Page</title>
   <meta name="description" content="A root page for a blog which Oration will service" />
   <meta name="author" content="Tim DuBois" />
-
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0-alpha1/katex.min.css" integrity="sha256-4lrFyxjMOLNOfyPQWjnxwmnJsWYbUdFHwTKkKSafVd0=" crossorigin="anonymous" />
   <link rel="stylesheet" href="css/oration.css" />
-
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0-alpha1/katex.min.js" integrity="sha256-kl3hugJz63EoVRjcvRBldeqsKUyy2WTMnHZMvBGX1Ns=" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0-alpha1/contrib/auto-render.min.js" integrity="sha256-wnhtH2tRmCyaM/epTHvAOLq7iEq0NFTc24a0UeyNK7c=" crossorigin="anonymous"></script>
   <!--[if lt IE 9]>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js"></script>
   <![endif]-->


### PR DESCRIPTION
This is a half assed attempt at #58, but it's failing pretty hard. Splitting up the system into `human` and `display` as in cb39c67 is annoying and overkill, but just printing values identified as in 0595fed doesn't render. In fact, I can only seem to get the elm-katex demo working, which has precompiled text. That's not something that is ever going to be useful, so I need to look at alternate methods.