### PR TITLE
Katex with ports

### DIFF
--- a/app/elm/Main.elm
+++ b/app/elm/Main.elm
@@ -35,6 +35,7 @@ init location =
       , httpResponse = ""
       , now = dateTime zero
       , blogAuthor = ""
+      , math = ""
       }
     , initialise location
     )

--- a/app/elm/Models.elm
+++ b/app/elm/Models.elm
@@ -17,4 +17,5 @@ type alias Model =
     , httpResponse : String
     , now : DateTime
     , blogAuthor : String
+    , math : String
     }

--- a/app/elm/Msg.elm
+++ b/app/elm/Msg.elm
@@ -26,3 +26,5 @@ type Msg
     | GetDate Time
     | NewDate DateTime
     | CommentReply Int
+    | Math String
+    | GetMath

--- a/app/elm/Ports.elm
+++ b/app/elm/Ports.elm
@@ -1,4 +1,4 @@
-port module Ports exposing (email, name, preview, setEmail, setName, setPreview, setUrl, title, url)
+port module Ports exposing (email, name, parsedMath, preview, renderMath, setEmail, setName, setPreview, setUrl, title, url)
 
 {- port for listening for document title from JavaScript -}
 
@@ -44,3 +44,13 @@ port preview : (String -> msg) -> Sub msg
 
 
 port setPreview : String -> Cmd msg
+
+
+
+{- Run Katex interop -}
+
+
+port renderMath : String -> Cmd msg
+
+
+port parsedMath : (String -> msg) -> Sub msg

--- a/app/elm/Update.elm
+++ b/app/elm/Update.elm
@@ -149,6 +149,12 @@ update msg model =
         NewDate date ->
             { model | now = date } ! []
 
+        Math newMath ->
+            { model | math = newMath } ! []
+
+        GetMath ->
+            model ! [ Ports.renderMath model.comment ]
+
         CommentReply id ->
             let
                 current =
@@ -171,6 +177,7 @@ subscriptions model =
         , Ports.email UpdateEmail
         , Ports.url UpdateUrl
         , Ports.preview SetPreview
+        , Ports.parsedMath Math
         , Time.every minute GetDate
         ]
 

--- a/app/elm/View.elm
+++ b/app/elm/View.elm
@@ -4,9 +4,10 @@ import Crypto.Hash
 import Data.Comment exposing (Comment, Responses(Responses))
 import Data.User exposing (User)
 import Html exposing (..)
-import Html.Attributes exposing (autocomplete, checked, cols, defaultValue, disabled, for, href, method, minlength, name, placeholder, rows, type_, value)
+import Html.Attributes exposing (autocomplete, checked, cols, defaultValue, disabled, for, href, method, minlength, name, placeholder, property, rows, type_, value)
 import Html.Events exposing (onClick, onInput, onSubmit)
 import Identicon exposing (identicon)
+import Json.Encode exposing (string)
 import Markdown
 import Maybe.Extra exposing ((?), isJust, isNothing)
 import Models exposing (Model)
@@ -43,6 +44,7 @@ view model =
         , div [ id Style.OrationDebug ] [ text model.httpResponse ]
         , div [ id Style.OrationCommentPreview ] <|
             Markdown.toHtml Nothing markdown
+        , div [ property "innerHTML" <| string model.math ] []
         , ul [ id Style.OrationComments ] <| printComments model
         ]
 
@@ -110,6 +112,7 @@ commentForm model formID =
         , div [ class [ Style.Control ] ]
             [ input [ type_ "checkbox", id Style.OrationPreviewCheck, checked model.user.preview, onClick UpdatePreview ] []
             , label [ for (toString Style.OrationPreviewCheck) ] [ text "Preview" ]
+            , input [ type_ "button", value "Math", onClick GetMath ] []
             , input [ type_ "submit", class [ Style.Submit ], disabled buttonDisable, value "Comment", onClick StoreUser ] []
             ]
         ]

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -39,4 +39,8 @@ if (elmDiv) {
     app.ports.setPreview.subscribe(function(state) {
         localStorage.setItem('preview', state);
     });
+    app.ports.renderMath.subscribe(function(state) {
+        var html = katex.renderToString(state);
+        app.ports.parsedMath.send(html);
+    });
 }

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -7,9 +7,9 @@
   <title>Oration - Test Index Page</title>
   <meta name="description" content="A root page for a blog which Oration will service" />
   <meta name="author" content="Tim DuBois" />
-
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0-alpha1/katex.min.css" integrity="sha256-4lrFyxjMOLNOfyPQWjnxwmnJsWYbUdFHwTKkKSafVd0=" crossorigin="anonymous" />
   <link rel="stylesheet" href="css/oration.css" />
-
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0-alpha1/katex.min.js" integrity="sha256-kl3hugJz63EoVRjcvRBldeqsKUyy2WTMnHZMvBGX1Ns=" crossorigin="anonymous"></script>
   <!--[if lt IE 9]>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js"></script>
   <![endif]-->


### PR DESCRIPTION
An MWE proof of concept connecting to katex with ports (an attempt at implementing #58 without the issues in #60).

The major ugliness of doing this is twofold: we have to fire off events, which will error if we don't parse correctly; and our return is structured HTML, which for the moment, doesn't seem to want to parse through the Markdown parser, forcing us to use an `InnerHTML` hack. This may be because of the defaults in our markdown renderer, which I need to check. 