### PR TITLE
Implement a notification system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,7 @@ argon2rs = { version = "0.2", features = ["simd"] }
 rust-crypto = "^0.2"
 itertools = "0.6"
 petgraph = "0.4"
+lettre = "0.7"
+lettre_email = "0.7"
+lazy_static = "0.2"
+regex = "0.2"

--- a/oration.yaml
+++ b/oration.yaml
@@ -11,6 +11,8 @@
 
 # Top level location of your blog
 host: http://localhost:8600/
+# Name of your blog
+blog_name: Testing ground
 
 # Salt for argon2 hashing. Note this is NOT used for passwords, only for keeping things somewhat anonymous.
 salt: 3BooSGokWgZXfae7WxhGZ
@@ -25,3 +27,17 @@ author:
 # Maximum thread nesting value. Depending on your layout, comments will get really bunched up and difficult
 # to read. So replies after a certain depth will no longer nest, but instead just respond to the current parent.
 nesting_limit: 6
+
+# Email notifications can be sent to you when certain events occur. Toggle each boolean value you wish to be
+# notified of here, and set up your smtp server details below. These values are sent encrypted by default.
+# For now, your pasword will be plain text in this file, so make sure your permissions are tight. In future
+# versions of Oration an init script will save your password in a strongly encrypted format in the database.
+notifications:
+  new_comment: false
+  smtp_server:
+    host:
+    user_name:
+    password:
+  recipient:
+    email:
+    name:

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,0 +1,36 @@
+
+//NOTE: we can use FormInput<'c>, url: &'c RawStr, for unvalidated data if/when we need it.
+#[derive(Debug, FromForm)]
+/// Incoming data from the web based form for a new comment.
+pub struct FormInput {
+    /// Comment from textarea.
+    pub comment: String,
+    /// Parent comment if any.
+    pub parent: Option<i32>,
+    /// Optional name.
+    pub name: Option<String>,
+    /// Optional email.
+    pub email: Option<String>,
+    /// Optional website.
+    pub url: Option<String>,
+    /// Title of post.
+    pub title: String,
+    /// Path of post.
+    pub path: String,
+}
+
+impl FormInput {
+    /// Yields the senders name with a default if is empty.
+    pub fn sender_name(&self) -> String {
+        self.name.to_owned().unwrap_or_else(
+            || "anonymous".to_string(),
+        )
+    }
+
+    /// Yields the senders email address with a default if is empty.
+    pub fn sender_email(&self) -> String {
+        self.email.to_owned().unwrap_or_else(
+            || "noreply@dev.null".to_string(),
+        )
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -40,6 +40,14 @@ error_chain!{
                 description("No HTTP handle")
                 display("The configuration parameter 'host' requires either a http:// or https:// prefix")
         }
+        EmptySMTP {
+                description("Invalid SMTP configuration")
+                display("Email notifications have been enabled, but one or more of the SMTP server configuration options are empty.")
+        }
+        EmptyRecipientEmail {
+                description("Invalid Recipient configuration")
+                display("Email notifications have been enabled, but no email address has been given to send notifications to.")
+        }
         Request {
                 description("HTTP request failed")
                 display("Could not generate HTTP request")
@@ -47,6 +55,18 @@ error_chain!{
         PathCheckFailed {
                 description("Requested path does not exist")
                 display("Could not find path on blog server")
+        }
+        BuildEmail {
+                description("Failed to build email")
+                display("Could not construct notification email")
+        }
+        SendEmail {
+                description("Failed to send email")
+                display("Could not send notification email")
+        }
+        BuildSmtpTransport {
+                description("Failed SMTP handshake")
+                display("Could not attach to SMTP server")
         }
     }
 }

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -1,0 +1,76 @@
+use lettre::smtp::authentication::{Credentials, Mechanism};
+use lettre::{EmailTransport, SmtpTransport};
+use lettre_email::EmailBuilder;
+
+use errors::*;
+use config::Notifications;
+use data::FormInput;
+use regex::Regex;
+
+/// Parses a URL, returning just the domain portion. The regex is overkill for this at the moment,
+/// but I think it may be usefull in the future to have this ability.
+fn get_domain(host: &str) -> &str {
+    lazy_static! {
+        // Matches 4 groups: protocol, domain, port, path.
+        static ref URLPARSE: Regex = Regex::new(r"(?i)(https?)://([^\s/?#_:]+\.?)+:?(\d+)?(/[^\s]*)?$").unwrap();
+    }
+    let caps = URLPARSE.captures(host).unwrap();
+
+    caps.get(2).map_or("noreply", |m| m.as_str())
+}
+
+/// Sends an email to a recipient listed in the configuration file when a new comment is posted, so
+/// long as the notification system is enabled (this check is elsewhere).
+pub fn send_notification(
+    form: &FormInput,
+    notify: &Notifications,
+    host: &str,
+    blog_name: &str,
+    ip_addr: &str,
+) -> Result<()> {
+
+    let post_url = format!("{}{}", host.trim_right_matches('/'), form.path);
+    let oration_addr = format!("oration@{}", get_domain(host));
+    let recipient_name = if notify.recipient.name == "~" {
+        "Oration Admin".to_string()
+    } else {
+        notify.recipient.name.to_owned()
+    };
+
+    let email = EmailBuilder::new()
+        .to((notify.recipient.email.to_owned(), recipient_name))
+        .from((oration_addr, "Oration Watchdog"))
+        .reply_to((form.sender_email(), form.sender_name()))
+        .subject(format!("A new comment has been posted on {}", blog_name))
+        .text(format!(
+"A comment has been posted by {} on a post titled: {}.
+
+The comment reads:
+{}
+
+You may reply on your blog post ({}), or if the user has left an email address, responding to this message will deliver them an email.
+
+Debug information:
+{:?}
+
+Commenter's IP: {}",
+                form.sender_name(), form.title, form.comment, post_url, form, ip_addr))
+        .build()
+        .chain_err(|| ErrorKind::BuildEmail)?;
+
+    // Connect to a remote server on a custom port
+    let mut mailer = SmtpTransport::simple_builder(notify.smtp_server.host.to_owned())
+        .chain_err(|| ErrorKind::BuildSmtpTransport)?
+        // Add credentials for authentication
+        .credentials(Credentials::new(notify.smtp_server.user_name.to_owned(), notify.smtp_server.password.to_owned()))
+        // Enable SMTPUTF8 if the server supports it
+        .smtp_utf8(true)
+        // Configure expected authentication mechanism
+        .authentication_mechanism(Mechanism::Plain)
+        .build();
+
+
+    mailer.send(&email).chain_err(|| ErrorKind::SendEmail)?;
+
+    Ok(())
+}


### PR DESCRIPTION
This PR implements a secure notification system which sends an email to a configured user when a new comment is made. It's ready to merge now, although there are two caveats that will need to be considered in the future:

1. > Rocket is currently built on a synchronous HTTP backend. Once the Rust asynchronous I/O libraries have stabilized, a migration to a new, more performant HTTP backend is planned.

   I'm unsure if this means I can't add threads into the system or not, but what I do know is the current system pushes the comment, we put it into the db, set the OK response, send the email, then return the OK response. I would like to swap the last two steps, but am unsure how right now.

2. The current implementation requires an admin to assign their smtp server credentials in plain text in the config file. It would be better if we had a configuration module that allowed us to store those details encrypted into the database. I remember clap had an option that we could make little subapplications. Investigate that for the future.  