### PR TITLE
Print just-posted comment to screen

### DIFF
--- a/app/elm/Data/User.elm
+++ b/app/elm/Data/User.elm
@@ -1,9 +1,11 @@
-module Data.User exposing (User, decoder, encode)
+module Data.User exposing (User, decoder, encode, getIdentity)
 
+import Crypto.Hash
 import Json.Decode as Decode exposing (Decoder)
 import Json.Decode.Pipeline exposing (decode, required)
 import Json.Encode as Encode exposing (Value)
 import Json.Encode.Extra as EncodeExtra
+import Maybe.Extra exposing ((?), isNothing)
 import Util exposing ((=>))
 
 
@@ -14,6 +16,27 @@ type alias User =
     , iphash : Maybe String
     , preview : Bool
     }
+
+
+
+{- Hashes user information depending on available data -}
+
+
+getIdentity : User -> String
+getIdentity user =
+    let
+        data =
+            [ user.name, user.email, user.url ]
+
+        --I think Maybe.Extra.values could also be used here
+        unwrapped =
+            List.filterMap identity data
+    in
+    if List.all isNothing data then
+        user.iphash ? ""
+    else
+        -- Join with b since it gives the authors' credentials a cool identicon
+        Crypto.Hash.sha224 (String.join "b" unwrapped)
 
 
 

--- a/app/elm/Main.elm
+++ b/app/elm/Main.elm
@@ -32,7 +32,7 @@ init location =
       , count = 0
       , post = location
       , title = ""
-      , postResponse = ""
+      , debug = ""
       , now = dateTime zero
       , blogAuthor = ""
       }

--- a/app/elm/Main.elm
+++ b/app/elm/Main.elm
@@ -32,7 +32,7 @@ init location =
       , count = 0
       , post = location
       , title = ""
-      , httpResponse = ""
+      , postResponse = ""
       , now = dateTime zero
       , blogAuthor = ""
       }

--- a/app/elm/Models.elm
+++ b/app/elm/Models.elm
@@ -14,7 +14,7 @@ type alias Model =
     , count : Int
     , post : Location
     , title : String
-    , httpResponse : String
+    , postResponse : String
     , now : DateTime
     , blogAuthor : String
     }

--- a/app/elm/Models.elm
+++ b/app/elm/Models.elm
@@ -1,6 +1,6 @@
 module Models exposing (Model)
 
-import Data.Comment exposing (Comment)
+import Data.Comment exposing (Comment, Inserted)
 import Data.User exposing (User)
 import Navigation exposing (Location)
 import Time.DateTime exposing (DateTime)
@@ -14,7 +14,7 @@ type alias Model =
     , count : Int
     , post : Location
     , title : String
-    , postResponse : String
+    , debug : String
     , now : DateTime
     , blogAuthor : String
     }

--- a/app/elm/Msg.elm
+++ b/app/elm/Msg.elm
@@ -1,6 +1,6 @@
 module Msg exposing (..)
 
-import Data.Comment exposing (Comment)
+import Data.Comment exposing (Comment, Inserted)
 import Data.Init exposing (Init)
 import Http
 import Navigation exposing (Location)
@@ -20,7 +20,7 @@ type Msg
     | StoreUser
     | Title String
     | PostComment
-    | PostConfirm (Result Http.Error String)
+    | PostConfirm (Result Http.Error Inserted)
     | Hashes (Result Http.Error Init)
     | Comments (Result Http.Error (List Comment))
     | GetDate Time

--- a/app/elm/Msg.elm
+++ b/app/elm/Msg.elm
@@ -20,7 +20,7 @@ type Msg
     | StoreUser
     | Title String
     | PostComment
-    | ReceiveHttp (Result Http.Error String)
+    | PostConfirm (Result Http.Error String)
     | Hashes (Result Http.Error Init)
     | Comments (Result Http.Error (List Comment))
     | GetDate Time

--- a/app/elm/Request/Comment.elm
+++ b/app/elm/Request/Comment.elm
@@ -1,6 +1,6 @@
 module Request.Comment exposing (comments, count, post)
 
-import Data.Comment as Comment exposing (Comment)
+import Data.Comment as Comment exposing (Comment, Inserted)
 import Http
 import HttpBuilder
 import Json.Decode as Decode
@@ -21,7 +21,7 @@ count location =
 
 {-| We want to override the default post behaviour of the form and send this data seemlessly to the backend
 -}
-post : Model -> Http.Request String
+post : Model -> Http.Request Inserted
 post model =
     let
         --These values will always be sent
@@ -32,6 +32,9 @@ post model =
             ]
 
         --User details are only sent if they exist
+        expect =
+            Comment.insertDecoder
+                |> Http.expectJson
     in
     "/oration"
         |> HttpBuilder.post
@@ -41,7 +44,7 @@ post model =
                 ++ prependMaybe body "email" model.user.email
                 ++ prependMaybe body "url" model.user.url
             )
-        |> HttpBuilder.withExpect Http.expectString
+        |> HttpBuilder.withExpect expect
         |> HttpBuilder.toRequest
 
 

--- a/app/elm/Update.elm
+++ b/app/elm/Update.elm
@@ -1,6 +1,7 @@
 module Update exposing (currentDate, subscriptions, update)
 
 import Data.Comment as Comment
+import Data.User exposing (getIdentity)
 import Http
 import Maybe.Extra exposing ((?))
 import Models exposing (Model)
@@ -99,16 +100,24 @@ update msg model =
                   ]
 
         PostConfirm (Ok result) ->
+            let
+                author =
+                    getIdentity model.user
+
+                comments =
+                    Comment.insertNew result ( model.comment, author, model.now, model.comments )
+            in
             { model
                 | comment = ""
                 , parent = Nothing
                 , count = model.count + 1
-                , postResponse = result
+                , debug = toString result
+                , comments = comments
             }
                 ! []
 
         PostConfirm (Err error) ->
-            { model | postResponse = toString error } ! []
+            { model | debug = toString error } ! []
 
         Hashes (Ok result) ->
             let
@@ -121,8 +130,8 @@ update msg model =
             }
                 ! []
 
-        Hashes (Err _) ->
-            model ! []
+        Hashes (Err error) ->
+            { model | debug = toString error } ! []
 
         Comments (Ok result) ->
             let
@@ -135,8 +144,8 @@ update msg model =
             }
                 ! []
 
-        Comments (Err _) ->
-            model ! []
+        Comments (Err error) ->
+            { model | debug = toString error } ! []
 
         GetDate _ ->
             model ! [ Task.perform NewDate currentDate ]

--- a/app/elm/Update.elm
+++ b/app/elm/Update.elm
@@ -89,31 +89,26 @@ update msg model =
             { model | title = value } ! []
 
         PostComment ->
-            { model
-                | comment = ""
-                , parent = Nothing
-                , count = model.count + 1
-            }
+            model
                 ! [ let
                         postReq =
                             Request.Comment.post model
                                 |> Http.toTask
                     in
-                    Task.attempt ReceiveHttp postReq
+                    Task.attempt PostConfirm postReq
                   ]
 
-        --TODO: Proper responses are needed
-        ReceiveHttp result ->
-            let
-                response =
-                    case result of
-                        Ok val ->
-                            val
+        PostConfirm (Ok result) ->
+            { model
+                | comment = ""
+                , parent = Nothing
+                , count = model.count + 1
+                , postResponse = result
+            }
+                ! []
 
-                        Err _ ->
-                            "Error!"
-            in
-            { model | httpResponse = response } ! []
+        PostConfirm (Err error) ->
+            { model | postResponse = toString error } ! []
 
         Hashes (Ok result) ->
             let

--- a/app/elm/Update.elm
+++ b/app/elm/Update.elm
@@ -80,8 +80,8 @@ update msg model =
             in
             { model | count = intCount } ! []
 
-        Count (Err _) ->
-            model ! []
+        Count (Err error) ->
+            { model | debug = toString error } ! []
 
         Post location ->
             { model | post = location } ! []
@@ -116,6 +116,9 @@ update msg model =
             }
                 ! []
 
+        --! [ Ports.scrollTo ("comment-" ++ toString result.id) ]
+        --! [ Dom.focus "comment-30" |> Task.attempt (always NoOp) ]
+        --! [ toTop ("comment-" ++ toString result.id) |> Task.attempt ScrollResult ]
         PostConfirm (Err error) ->
             { model | debug = toString error } ! []
 

--- a/app/elm/View.elm
+++ b/app/elm/View.elm
@@ -40,7 +40,7 @@ view model =
     div [ id Style.Oration ]
         [ h2 [] [ text count ]
         , commentForm model Style.OrationForm
-        , div [ id Style.OrationDebug ] [ text model.httpResponse ]
+        , div [ id Style.OrationDebug ] [ text model.postResponse ]
         , div [ id Style.OrationCommentPreview ] <|
             Markdown.toHtml Nothing markdown
         , ul [ id Style.OrationComments ] <| printComments model

--- a/app/elm/View.elm
+++ b/app/elm/View.elm
@@ -160,8 +160,8 @@ printComment comment model =
         created =
             inWords model.now comment.created
 
-        id =
-            toString comment.id
+        commentId =
+            "comment-" ++ toString comment.id
 
         buttonText =
             if model.parent == Just comment.id then
@@ -187,7 +187,7 @@ printComment comment model =
             else
                 "[+" ++ toString (count <| List.singleton comment) ++ "]"
     in
-    li [ name ("comment-" ++ id), class headerStyle ]
+    li [ id commentId, class headerStyle ]
         [ span [ class [ Style.Identicon ] ] [ identicon "25px" comment.hash ]
         , printAuthor author
         , span [ class [ Style.Spacer ] ] [ text "•" ]

--- a/app/elm/View.elm
+++ b/app/elm/View.elm
@@ -1,14 +1,13 @@
 module View exposing (view)
 
-import Crypto.Hash
 import Data.Comment exposing (Comment, Responses(Responses), count)
-import Data.User exposing (User)
+import Data.User exposing (User, getIdentity)
 import Html exposing (..)
 import Html.Attributes exposing (autocomplete, checked, cols, defaultValue, disabled, for, href, method, minlength, name, placeholder, rows, type_, value)
 import Html.Events exposing (onClick, onInput, onSubmit)
 import Identicon exposing (identicon)
 import Markdown
-import Maybe.Extra exposing ((?), isJust, isNothing)
+import Maybe.Extra exposing ((?), isJust)
 import Models exposing (Model)
 import Msg exposing (Msg(..))
 import Style
@@ -40,7 +39,7 @@ view model =
     div [ id Style.Oration ]
         [ h2 [] [ text count ]
         , commentForm model Style.OrationForm
-        , div [ id Style.OrationDebug ] [ text model.postResponse ]
+        , div [ id Style.OrationDebug ] [ text model.debug ]
         , div [ id Style.OrationCommentPreview ] <|
             Markdown.toHtml Nothing markdown
         , ul [ id Style.OrationComments ] <| printComments model
@@ -68,10 +67,10 @@ commentForm model formID =
 
         textAreaValue =
             if formID == Style.OrationForm then
-                if isNothing model.parent then
-                    model.comment
-                else
+                if isJust model.parent then
                     ""
+                else
+                    model.comment
             else
                 --OrationReplyForm
                 model.comment
@@ -137,27 +136,6 @@ markdownContent content preview =
         content
     else
         ""
-
-
-
-{- Hashes user information depending on available data -}
-
-
-getIdentity : User -> String
-getIdentity user =
-    let
-        data =
-            [ user.name, user.email, user.url ]
-
-        --I think Maybe.Extra.values could also be used here
-        unwrapped =
-            List.filterMap identity data
-    in
-    if List.all isNothing data then
-        user.iphash ? ""
-    else
-        -- Join with b since it gives the authors' credentials a cool identicon
-        Crypto.Hash.sha224 (String.join "b" unwrapped)
 
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ use rocket::{State, Response};
 use rocket::request::Form;
 use rocket_contrib::Json;
 use models::preferences::Preference;
-use models::comments::{NestedComment, Comment};
+use models::comments::{InsertedComment, NestedComment, Comment};
 use models::threads;
 use std::process;
 use yansi::Paint;
@@ -99,7 +99,7 @@ fn new_comment<'a>(
     comment: Result<Form<FormInput>, Option<String>>,
     config: State<Config>,
     remote_addr: SocketAddr,
-) -> Result<Json<NestedComment>, Response<'a>> {
+) -> Result<Json<InsertedComment>, Response<'a>> {
     let mut response = Response::new();
     match comment {
         Ok(f) => {


### PR DESCRIPTION
WIP for #31

- [x] Return comment in nested format to frontend
- [x] Rename `RecieveHttp` so something more apt
- [x] Leverage this new Cmd to print the comment to screen. This will need to be main box vs reply box aware.
- [ ] ~Scroll to new comment, let user know it may be under moderation (along with a message, perhaps slightly grey?)~

For now, since we've yet to implement moderation, we don't need to do anything else for this. Later, if a site has admin moderation on, we may want to store user comments locally with some kind of hash until the admin has approved/deleted it.