### PR TITLE
Coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,5 +64,5 @@ matrix:
         - elm-make --yes
         - elm-css Stylesheets.elm
         - elm-coverage .
+        - cat .coverage/coverage.html
         - cat .coverage/info.json
-        - for a in $(.coverage/*.json); do echo $a; cat $a; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,14 @@ matrix:
               ./ghp-import/ghp_import.py -n -p -f -m "Documentation upload" -r https://"$GH_TOKEN"@github.com/"$TRAVIS_REPO_SLUG.git" target/doc &&
               echo "Uploaded documentation"
             fi
+        # Coverage report
+        - |
+            if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "stable" ]]; then
+              bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
+              cargo tarpaulin --out Xml
+              bash <(curl -s https://codecov.io/bash)
+              echo "Uploaded code coverage"
+            fi
     - language: node_js
       node_js: node
       sudo: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,5 +65,5 @@ matrix:
         - cd app/elm
         - elm-make --yes
         - elm-css Stylesheets.elm
-        - elm-test
         - elm-coverage .
+        - cat .coverage/coverage.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
             fi
         # Coverage report
         - |
-            if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "stable" ]]; then
+            if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "nightly" ]]; then
               bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
               cargo tarpaulin --out Xml
               bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ matrix:
             fi
         # Coverage report
         - |
+            `RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin`
             bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
             cargo tarpaulin --out Xml
             bash <(curl -s https://codecov.io/bash)
@@ -64,5 +65,4 @@ matrix:
         - elm-make --yes
         - elm-css Stylesheets.elm
         - elm-coverage .
-        - cat .coverage/coverage.html
-        - cat .coverage/info.json
+        - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,4 +64,5 @@ matrix:
         - elm-make --yes
         - elm-css Stylesheets.elm
         - elm-coverage .
-        - ls .coverage
+        - cat .coverage/info.json
+        - for a in $(.coverage/*.json); do echo $a; cat $a; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,15 +40,30 @@ matrix:
             fi
     - language: node_js
       node_js: node
-      sudo: true
-      before_install:
-        - "npm install -g elm@0.18 elm-test elm-css"
+      os: linux
       cache:
         directories:
+          - sysconfcpus
+          - node_modules
           - app/elm/elm-stuff/build-artifacts
           - app/elm/tests/elm-stuff/build-artifacts
+      before_install:
+        - | # epic build time improvement - see https://github.com/elm-lang/elm-compiler/issues/1473#issuecomment-245704142
+            if [ ! -d sysconfcpus/bin ]; then
+              git clone https://github.com/obmarg/libsysconfcpus.git;
+              cd libsysconfcpus;
+              ./configure --prefix=$TRAVIS_BUILD_DIR/sysconfcpus;
+              make && make install;
+              cd ..;
+            fi
+      install:
+        - npm install -g elm@0.18 elm-test elm-coverage elm-css
+        - mv $(npm config get prefix)/bin/elm-make $(npm config get prefix)/bin/elm-make-old
+        - echo -e "#\!/bin/bash\\n\\necho \"Running elm-make with sysconfcpus -n 2\"\\n\\n$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make-old \"\$@\"" > $(npm config get prefix)/bin/elm-make
+        - chmod +x $(npm config get prefix)/bin/elm-make
       script:
         - cd app/elm
         - elm-make --yes
         - elm-css Stylesheets.elm
         - elm-test
+        - elm-coverage .

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,4 +66,4 @@ matrix:
         - elm-make --yes
         - elm-css Stylesheets.elm
         - elm-coverage .
-        - cat .coverage/coverage.html
+        - ls .coverage && exit 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,12 +32,10 @@ matrix:
             fi
         # Coverage report
         - |
-            if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "nightly" ]]; then
-              bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
-              cargo tarpaulin --out Xml
-              bash <(curl -s https://codecov.io/bash)
-              echo "Uploaded code coverage"
-            fi
+            bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
+            cargo tarpaulin --out Xml
+            bash <(curl -s https://codecov.io/bash)
+            echo "Uploaded code coverage"
     - language: node_js
       node_js: node
       os: linux
@@ -66,4 +64,4 @@ matrix:
         - elm-make --yes
         - elm-css Stylesheets.elm
         - elm-coverage .
-        - ls .coverage && exit 0
+        - ls .coverage


### PR DESCRIPTION
Will close #65 

Tarpaulin now functions as we'd like, so we should now be fine to integrate with codecov there.

As far as the elm side is concerned, there's little to do with coverage metrics atm. This branch is looking at `elm-coverage`, but it may not even be ready yet.